### PR TITLE
copy uncrustify's source to prevent issues caused by symlinking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,31 @@ project(uncrustify)
 include(ExternalProject)
 
 if(NOT WIN32)
+  # Make the destination for the source code.
+  set(uncrustify_source_dir "${CMAKE_CURRENT_BINARY_DIR}/uncrustify_src")
+  file(MAKE_DIRECTORY "${uncrustify_source_dir}")
+  # Touch a file there during configure time to prevent ExternalProject_Add from complaining about
+  # SOURCE_DIR being an empty folder.
+  execute_process(COMMAND
+    ${CMAKE_COMMAND} -E touch "${uncrustify_source_dir}/fool_external_project")
+  # Add a standard autotools external project, using the build space version of the source.
   ExternalProject_Add(
     external_uncrustify
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
-    CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/configure"
+    SOURCE_DIR "${uncrustify_source_dir}"
+    CONFIGURE_COMMAND "${uncrustify_source_dir}/configure"
       "--prefix" "${CMAKE_CURRENT_BINARY_DIR}"
     BUILD_COMMAND "${MAKE}"
+  )
+  # Always copy the source of uncrustify to the build space between the download and build steps.
+  # This prevents problems that occur when the source space is a symlinked directory.
+  # See: https://github.com/ament/uncrustify/issues/1
+  ExternalProject_Add_Step(external_uncrustify copy_source
+    DEPENDEES download
+    DEPENDERS build
+    COMMENT "Copy source to ${uncrustify_source_dir} to prevent problems with symlink."
+    ALWAYS 1  # Always do this otherwise changing the source would not change the built binary.
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/ ${uncrustify_source_dir}
   )
 
   install(
@@ -33,7 +52,9 @@ else()
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/win32/${build_type}/Uncrustify.exe"
     COMMAND "devenv" "/upgrade" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
-    COMMAND "msbuild" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln" "/p:Configuration=${build_type}" "/p:Platform=Win32"
+    COMMAND
+      "msbuild" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
+      "/p:Configuration=${build_type}" "/p:Platform=Win32"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/uncrustify_version.h"
   )


### PR DESCRIPTION
Fixes #1.

This is the only way that I can find how to get `uncrustify` to build when the source space is symlinked.

I'm not particularly happy with the result, since the copy is otherwise unnecessary, but on the other hand, this is likely to be a relatively common use case and the error is not straight forward to associate with this issue. The copy is quick (for my VM, ~1 sec on the first time and really fast on the follow up build).

I considered try to detect the symlink and only doing the copy in that case, but detecting the symlink condition is not trivial.

So I would consider merging it, but I understand if we choose to just leave this pull request closed for others to find in the future. I'm also happy to take suggestions on how else to solve the problem, but I don't want to spend a lot of time on the issue.
