### PR TITLE
Commit vs2015 upgrade of the solution file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT WIN32)
   # always copy the necessary source files of uncrustify to the build directory
   # since the upstream build scripts can't handle symlinked folders correctly
   set(copy_commands "")
-  file(GLOB_RECURSE source_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  file(GLOB_RECURSE src_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/configure"
     "${CMAKE_CURRENT_SOURCE_DIR}/etc/*.cfg"
     "${CMAKE_CURRENT_SOURCE_DIR}/install-sh"
@@ -36,7 +36,7 @@ if(NOT WIN32)
     "${CMAKE_CURRENT_SOURCE_DIR}/missing"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*"
   )
-  foreach(source_file ${source_files})
+  foreach(source_file ${src_files})
     # copy every file only when changed which will avoid recompilation if nothing changed
     list (APPEND copy_commands
       COMMAND
@@ -73,7 +73,7 @@ else()
 
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/win32/${build_type}/Uncrustify.exe"
-    COMMAND "devenv" "/upgrade" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
+    # COMMAND "devenv" "/upgrade" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
     COMMAND
       "msbuild" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
       "/p:Configuration=${build_type}" "/p:Platform=Win32"

--- a/win32/Uncrustify_Win32_2011.sln
+++ b/win32/Uncrustify_Win32_2011.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 11
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Uncrustify", "Uncrustify_Win32_2011.vcxproj", "{743E549D-6BCA-4E81-8DCF-C34B85AF8373}"
 EndProject
 Global

--- a/win32/Uncrustify_Win32_2011.vcxproj
+++ b/win32/Uncrustify_Win32_2011.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -13,17 +13,16 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{743E549D-6BCA-4E81-8DCF-C34B85AF8373}</ProjectGuid>
     <ProjectName>Uncrustify</ProjectName>
-    <VCTargetsPath Condition="'$(VCTargetsPath11)' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''">$(VCTargetsPath11)</VCTargetsPath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
So this is the third time the Windows machine has decided to self destruct with this license expiration:

http://54.183.26.131:8080/job/ros2_batch_ci_windows/240/console

```
         Microsoft Visual Studio 2015 RC Version 14.0.22823.1.
         Copyright (C) Microsoft Corp. All rights reserved.

         The license for Visual Studio has expired.

         The evaluation period for this product has ended.
```

This only happens when Jenkins is running the job. I cannot reproduce the problem when using `cmd.exe` from the desktop. I've tried:
- Running the Jenkins slave as my user.
- Force setting the `USERNAME` env variable to `osrf`.
- Getting a new developer license (https://msdn.microsoft.com/en-us/library/windows/apps/hh974578.aspx)
- Repairing the VS2015 installation.

None of these have worked. That last time I fixed this issue by reinstalling Windows...

The weird thing is that this failure only occurs when `uncrustify` runs `devenv` to upgrade the solution file, and not when invoking msbuild or compiling/linking. With this pull request I've committed that upgrade to the solution file and disabled the upgrade step in CMake. This at least allows the build to continue until it gets to the idl parser error https://github.com/ros2/rcl_interfaces/issues/2, see:

http://54.183.26.131:8080/job/ros2_batch_ci_windows/241/console

If I can't come up with another solution then this will have to be the work around for now.
