### PR TITLE
Use the cmake build type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,4 +9,8 @@
   <license>GNU GENERAL PUBLIC LICENSE Version 3</license>
 
   <url>https://github.com/bengardner/uncrustify</url>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This depends on https://github.com/ament/ament_tools/pull/33

By doing this we avoid some warnings about this package not using certain ament specific CMake variables.

Connects to ros2/ros2#53
